### PR TITLE
Fix "no lexical binding" warnings

### DIFF
--- a/parent-mode-test.el
+++ b/parent-mode-test.el
@@ -1,4 +1,4 @@
-;;; parent-mode-test.el --- parent-mode test suite
+;;; parent-mode-test.el --- parent-mode test suite  -*- lexical-binding: t; -*-
 
 ;; Author: Fanael Linithien <fanael4@gmail.com>
 ;; URL: https://github.com/Fanael/parent-mode

--- a/parent-mode.el
+++ b/parent-mode.el
@@ -1,4 +1,4 @@
-;;; parent-mode.el --- get major mode's parent modes
+;;; parent-mode.el --- get major mode's parent modes  -*- lexical-binding: t; -*-
 
 ;; Author: Fanael Linithien <fanael4@gmail.com>
 ;; URL: https://github.com/Fanael/parent-mode


### PR DESCRIPTION
Fixes 2 warnings:

    In toplevel form:
    parent-mode-test.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line

    In toplevel form:
    parent-mode.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line
